### PR TITLE
Bump actual budget to 24.12.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "actual-moneymoney",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "actual-moneymoney",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "license": "MIT",
             "dependencies": {
-                "@actual-app/api": "^24.11.0",
+                "@actual-app/api": "^24.12.0",
                 "chalk": "^5.3.0",
                 "date-fns": "^4.1.0",
                 "moneymoney": "^1.2.1",
@@ -41,9 +41,9 @@
             }
         },
         "node_modules/@actual-app/api": {
-            "version": "24.11.0",
-            "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-24.11.0.tgz",
-            "integrity": "sha512-z46vxeg2yF2OY0C1vry558A+FO3fbFik0Wh5PwKxODVNDM3omFB/pEikB1AAmZRfoTNxInis//flUvD+DUzHDA==",
+            "version": "24.12.0",
+            "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-24.12.0.tgz",
+            "integrity": "sha512-LT7mnp79xpBZAfrRMdKpiZKQEQ+zDY3nopwFaZQTUoY05BwpoypujC5TQe6q3QKBm3aFrq0bZXBa/hSnVAOvgw==",
             "dependencies": {
                 "@actual-app/crdt": "^2.1.0",
                 "better-sqlite3": "^9.6.0",
@@ -2579,9 +2579,9 @@
             "dev": true
         },
         "@actual-app/api": {
-            "version": "24.11.0",
-            "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-24.11.0.tgz",
-            "integrity": "sha512-z46vxeg2yF2OY0C1vry558A+FO3fbFik0Wh5PwKxODVNDM3omFB/pEikB1AAmZRfoTNxInis//flUvD+DUzHDA==",
+            "version": "24.12.0",
+            "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-24.12.0.tgz",
+            "integrity": "sha512-LT7mnp79xpBZAfrRMdKpiZKQEQ+zDY3nopwFaZQTUoY05BwpoypujC5TQe6q3QKBm3aFrq0bZXBa/hSnVAOvgw==",
             "requires": {
                 "@actual-app/crdt": "^2.1.0",
                 "better-sqlite3": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "actual-moneymoney",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "An importer for syncing MoneyMoney accounts and transactions to Actual.",
     "exports": "./index.js",
     "scripts": {
@@ -28,7 +28,7 @@
     "author": "NikxDa",
     "license": "MIT",
     "dependencies": {
-        "@actual-app/api": "^24.11.0",
+        "@actual-app/api": "^24.12.0",
         "chalk": "^5.3.0",
         "date-fns": "^4.1.0",
         "moneymoney": "^1.2.1",


### PR DESCRIPTION
With the old version one runs into this error: https://github.com/actualbudget/actual/issues/3384

(Namely, "Database is out of sync with migrations:")